### PR TITLE
fix: Cloud Run デプロイ時の起動失敗を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,16 @@ FROM node:16.15.0-alpine3.14
 WORKDIR /var/www
 RUN apk update && \
     yarn global add create-nuxt-app
-# 開発環境ではビルド時にinstallしない（起動後にボリューム経由で実行）
-COPY ./src/package*.json ./
-EXPOSE 3000
-EXPOSE 24678
 
-# commandはdocker-compose.yml側で制御
+# アプリケーションのビルド
+COPY ./src/package.json ./src/yarn.lock ./
+RUN yarn install
+
+COPY ./src ./
+RUN yarn build
+
+# Cloud Run 向けの設定
+ENV HOST 0.0.0.0
+EXPOSE 3000
+
+CMD ["yarn", "start"]

--- a/src/nuxt.config.js
+++ b/src/nuxt.config.js
@@ -80,6 +80,11 @@ export default {
   build: {
   },
 
+  server: {
+    port: process.env.PORT || 3000,
+    host: '0.0.0.0'
+  },
+
   publicRuntimeConfig: {
     siteURL: process.env.SITE_URL,
     storageURL: process.env.STORAGE_URL,


### PR DESCRIPTION
Cloud Run でコンテナが起動しなかった問題を修正しました。

### 変更点
- **Dockerfile:** プロダクションビルド（yarn build）と、実行コマンド（yarn start）を追加
- **nuxt.config.js:** Cloud Run の環境変数 PORT をリッスンし、外部ホスト（0.0.0.0）にバインドするように server 設定を追加