### PR TITLE
feat: モーダルフッターをスクロール領域最下部に移動 & 背景スクロール防止の実装

### DIFF
--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -1,24 +1,26 @@
 <template>
   <div>
     <div class="modal modal-overlay" @click.self="closeModal" v-show="modal">
-      <div class="modal modal-window md:w-9/12 w-11/12">
-        <component
-          class="modal content"
-          ref="modalContent"
-          :is="modalType"
-          :modalSet="modalSet"
-          :contentValue="contentValue"
-          :contentList="contentList"
-          @completeModal="completeModal($event)"
-        ></component>
-        <footer class="modal-footer">
-          <button class="close w-5/12 md:w-[150px]" @click="closeModal">
-            閉じる
-          </button>
-          <button class="clear w-5/12 md:w-[150px]" @click="clear">
-            未選択にする
-          </button>
-        </footer>
+      <div class="modal modal-window md:w-9/12 w-11/12 mx-auto">
+        <div class="modal-content-wrapper">
+          <component
+            class="modal-body"
+            ref="modalContent"
+            :is="modalType"
+            :modalSet="modalSet"
+            :contentValue="contentValue"
+            :contentList="contentList"
+            @completeModal="completeModal($event)"
+          ></component>
+          <footer class="modal-footer">
+            <button class="close w-5/12 md:w-[150px]" @click="closeModal">
+              閉じる
+            </button>
+            <button class="clear w-5/12 md:w-[150px]" @click="clear">
+              未選択にする
+            </button>
+          </footer>
+        </div>
       </div>
       <!-- </transition> -->
     </div>
@@ -65,6 +67,15 @@ export default {
       message: "",
       modal: false,
     };
+  },
+  watch: {
+    modal(val) {
+      if (val) {
+        document.body.style.overflow = "hidden";
+      } else {
+        document.body.style.overflow = "";
+      }
+    },
   },
   methods: {
     openModal() {
@@ -125,12 +136,23 @@ export default {
   /* opacity: 0; */
   transition: opacity 0.5s, transform 0s 0.5s;
   /* transform: scale(0); */
+  display: flex;
+  flex-direction: column;
 }
-.modal.content {
-  margin: 20px 10px 10px 20px;
-  padding: 40px;
-  max-height: calc(100vh - 300px);
+.modal-content-wrapper {
+  max-height: calc(100vh - 100px);
   overflow-y: auto;
+}
+.modal-body {
+  padding: 40px;
+}
+
+.modal-footer {
+  padding: 20px 40px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .modal-enter {
@@ -155,10 +177,6 @@ export default {
   transition: opacity 300ms ease-in, transform 270ms ease-in;
 }
 
-.modal-footer {
-  padding: 10px;
-}
-
 footer button {
   display: block;
   border: 1px solid hsla(0, 0%, 100%, 0.2);
@@ -166,7 +184,7 @@ footer button {
   text-shadow: 0 0 5px rgba(255, 255, 255, 0.5);
   color: aliceblue;
   padding: 10px 0px 10px 0px;
-  margin: 10px 20px 10px auto;
+  margin: 0;
   font-family: "Noto Serif JP", serif;
   transition: all 0.3s ease;
 }


### PR DESCRIPTION
## 概要
各モーダルのフッターボタン（「閉じる」「未選択にする」）を、コンテンツのスクロール領域最下部に移動しました。これにより、コンテンツが長い場合に最後までスクロールして初めてボタンが表示されるようになります。

## 変更内容
- **modal.vue**:
  - フッターをスクロールコンテナ内に移動
  - modal-body に適切なパディング（40px）を設定し、各コンポーネントのレイアウトを維持しつつ余白を確保
  - modal 表示状態を監視する watch を追加し、表示中に背景（body）のスクロールを固定する処理を実装
- **作成ブランチ**: feature/modal-footer-fix-latest（最新の main より分岐）